### PR TITLE
Cleaner selection text

### DIFF
--- a/style.css
+++ b/style.css
@@ -1054,3 +1054,7 @@ section.page:not(.focus):not(:hover)::-webkit-scrollbar {
 			column-fill: balance;
 		}
 }
+
+::selection {
+	text-shadow: none;
+}


### PR DESCRIPTION
Selected text looks blurry because of its text-shadow.
Removing the text-shadow produces clearer text in supporting browsers.
