### PR TITLE
Some minor webkit fixes for the “Help” page

### DIFF
--- a/help/style.css
+++ b/help/style.css
@@ -34,6 +34,8 @@ body {
 	font: 110%/1.5 Primary;
 	hyphens: auto;
 	text-shadow: 0 0.0847em white; /* See issue #134 */
+	text-rendering: optimizelegibility;
+	-webkit-font-smoothing: subpixel-antialiased; /* fix any issues caused by translateZ fix */
 }
 
 h1, h2 {
@@ -47,7 +49,6 @@ body > hgroup {
 	font-size: 400%;
 	line-height: .4;
 	-webkit-transform: translateZ(0); /* fix for chopped letters */
-	-webkit-font-smoothing: subpixel-antialiased; /* apply the proper antialiasing killed by previous fix */
 }
 
 	body > hgroup > h1 {


### PR DESCRIPTION
My inner perfectionist couldn't pass by looking at those little things :)

Here is a picture showing some of them:

![Here they are, the bugs](http://i.kizu.ru/misc/D/help.jpg)

I remembered that you said about the list markers that you wanted the effect shown only in Fx, so I've updated the styles adding the `list-style-position: inside`.

Also, there were some bugs in webkit on scroll: the top of the logo clipped and the ear of the “Q” letter stayed on place when you scrolled the page. I somehow always see such things :)

Also, I've done two minor improvements: made the clickable area of the nav links bigger and added `text-rendering: optimize legibility` to `body`, so the text would be nicer to read in webkits (Fx already uses that by default).
