### PR TITLE
Fixed #153

### DIFF
--- a/code/previewers.js
+++ b/code/previewers.js
@@ -57,7 +57,6 @@ var _ = self.Previewer = function(id, updater, type) {
 			
 			if(!token || !valid && oldToken) {
 				previewer.classList.remove('active');
-				previewer.style.display = '';
 			}
 		}
 	});
@@ -133,8 +132,8 @@ new Previewer('abslength', function(code) {
 		style.marginLeft = -num/2 + unit;
 		
 		style.display = 'block';
-		
 		var width = this.offsetWidth;
+		style.display = '';
 
 		if(width > innerWidth || width < 9) {
 			valid = false;


### PR DESCRIPTION
The `#abslength` previewer had its display set through .style.
While this is necessary to get the previewer's offsetWidth, it's not necessary afterwards.

Removing the style.display manipulations and relying on the `active` class to make the previewer visible remedies issue #153 (length previews appearing when they shouldn't).
