### PR TITLE
Dropdown menu pointer overlaps hovered buttons

### DIFF
--- a/style/global.css
+++ b/style/global.css
@@ -315,6 +315,7 @@ body > header.focus {
 		.dropdown:before {
 			content: '';
 			position: absolute;
+			z-index: -1;
 			top: -6px;
 			left: 2.5em;
 			width: 12px;


### PR DESCRIPTION
Before:
<img src="http://i1271.photobucket.com/albums/jj626/GeorgeTzellis/dropMenuBefore.png">

After:
<img src="http://i1271.photobucket.com/albums/jj626/GeorgeTzellis/dropMenuAfter.png">
