### PR TITLE
Safari 6 doesn't play previewer animations

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -449,7 +449,7 @@ body[data-seethrough] .line-highlight {
 .previewer.active {
 	display: block;
 	transform-origin: 50% 100%;
-	animation: .2s previewer;
+	animation: previewer .2s;
 	animation-timing-function: cubic-bezier(.5,0,.7,1.8);
 }
 


### PR DESCRIPTION
Safari 6, stricter than 5, expects the first property in the `animation` shorthand to be `animation-name`.
