### PR TITLE
Line-delimiter scrolls (#171), is unobtrusive

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -191,10 +191,8 @@ html.supports-range label.slider {
 	display: none;
 	box-sizing: border-box;
 	height: 100%;
-	box-sizing: border-box;
 	overflow: auto;
-	background: url(/img/noise.png), linear-gradient(left, hsl(24,20%,91%) 1px, transparent 1px) 2.8em 0 no-repeat;
-	background-color: hsl(24, 20%, 95%);
+	background: url(/img/noise.png) hsl(24, 20%, 95%);
 	font: 100%/1.5em Monaco, Consolas, Inconsolata, 'Deja Vu Sans Mono', 'Droid Sans Mono', 'Andale Mono', 'Lucida Console', monospace;
 	tab-size: 4;
 	word-wrap: normal;
@@ -226,6 +224,9 @@ body[data-seethrough] .editor.page > pre > span.token {
 		position: relative;
 		padding: 1em 1.5em 1em 3em;
 		overflow: visible;
+		background: linear-gradient(left, hsl(24, 20%, 87%) 1px, hsl(24, 20%, 95%)) -3px no-repeat;
+		background-size: 2px 100%;
+		background-origin: content-box;
 		word-wrap: normal;
 		font: inherit;
 		outline: none;


### PR DESCRIPTION
The line-delimiter used to remain at the same position when the editor scrolled horizontally, betraying its function.

The new line-delimiter also limits itself to the content you've written.
You can now tell when there are empty lines at the end of your input, and distinguish between 1 empty line and 10.
I think this is a good pairing with the unobtrusive design of the line-number indicator.
