### PR TITLE
Change matching of user's name on profile page. fixes #186

### DIFF
--- a/code/user-profile.js
+++ b/code/user-profile.js
@@ -5,7 +5,7 @@
  
 (function (html) {
 
-var username = (location.pathname.match(/\/user\/([^\/]+)/i) || [,''])[1].trim();
+var username = (location.pathname.match(/\/user\/([\w-]+)/i) || [,''])[1].trim();
 
 if(username) {
 	document.title = username + '’s profile';


### PR DESCRIPTION
Changed regexp for matching user names on profile page so that user with dashes in names wouldn't feel left out.
