### PR TITLE
Escape `&` as `&amp;`

### DIFF
--- a/code/editor.js
+++ b/code/editor.js
@@ -246,7 +246,7 @@ var _ = window.Editor = function(pre) {
 				
 				var pasted = evt.clipboardData.getData("text/plain");
 				
-				document.execCommand("insertHTML", false, pasted.replace(/</g, '&lt;'));
+				document.execCommand("insertHTML", false, pasted.replace(/</g, '&lt;').replace(/&/g, '&amp;'));
 				
 				that.undoManager.action({
 					add: pasted,


### PR DESCRIPTION
Previously, copying `&ampamp;` or `&amp;amp;` and pasting it into Dabblet would actually insert the text: `&amp;`. This patch fixes that.
