### PR TITLE
issue#193 fixed 

### DIFF
--- a/result/index.php
+++ b/result/index.php
@@ -22,7 +22,21 @@ if($gist_id) {
 	$uri .= "?client_id=$client_id&client_secret=$client_secret";
 	
 	try {
-		$raw = file_get_contents($uri);
+                //curl call with user agent header.
+		$curl = curl_init();		
+		$agent= 'Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.102 Safari/537.36';
+		
+		curl_setopt_array($curl, array(
+			CURLOPT_RETURNTRANSFER => 1,
+			CURLOPT_URL => $uri,
+			CURLOPT_SSL_VERIFYPEER => 0,
+			CURLOPT_SSL_VERIFYHOST => 0,
+			CURLOPT_VERBOSE => 0,
+			CURLOPT_USERAGENT => $agent
+		));		
+		
+		$raw = curl_exec($curl);
+		curl_close($curl);
 	}
 	catch(Exception $e) {
 		echo $e;


### PR DESCRIPTION
issue#193 fixed by replacing get_file_content for curl call with user-agent header(Requested by Github otherwise error thrown by API User-Agent Required).
Issue Detail:
When you fetch try to fetch URL content with file_get_content. Your not sending the User-Agent Header which is requested by Github API.
Following is the Response Error Message.
Error Response:"Request forbidden by administrative rules. Please make sure your request has a User-Agent header (http://developer.github.com/v3/#user-agent-required). Check https://developer.github.com for other possible causes.'"
