### PR TITLE
Make 'crlf' a local variable instead of global

### DIFF
--- a/code/editor.js
+++ b/code/editor.js
@@ -4,7 +4,7 @@
  
 (function(){
 
-var crlf, CRLF = crlf = /\r?\n|\r/g;
+var CRLF = /\r?\n|\r/g;
 
 var UndoManager = function(editor) {
 	this.editor = editor;

--- a/code/editor.js
+++ b/code/editor.js
@@ -4,7 +4,7 @@
  
 (function(){
 
-var CRLF = crlf = /\r?\n|\r/g;
+var crlf, CRLF = crlf = /\r?\n|\r/g;
 
 var UndoManager = function(editor) {
 	this.editor = editor;

--- a/code/prism.js
+++ b/code/prism.js
@@ -592,7 +592,7 @@ function hasClass(element, className) {
   return (" " + element.className + " ").replace(/[\n\t]/g, " ").indexOf(className) > -1
 }
 
-var CRLF = crlf = /\r?\n|\r/g;
+var CRLF = /\r?\n|\r/g;
     
 function highlightLines(pre, lines, classes) {
 	var ranges = lines.replace(/\s+/g, '').split(','),


### PR DESCRIPTION
Fixed a slight issue on [line 7 of code/editor.js](https://github.com/LeaVerou/dabblet/blob/master/code/editor.js#L7) where `crlf` was being defined in the global scope instead of the local scope.