### PR TITLE
Fixed paste issue

### DIFF
--- a/code/editor.js
+++ b/code/editor.js
@@ -245,8 +245,8 @@ var _ = window.Editor = function(pre) {
 				evt.preventDefault();
 
 				var pasted = evt.clipboardData.getData("text/plain");
-				
-				document.execCommand("insertText", false, pasted.replace(/\n/g, "\r\n"));
+
+				document.execCommand("insertText", false, pasted.replace(CRLF, "\r\n"));
 
 				that.undoManager.action({
 					add: pasted,


### PR DESCRIPTION
This fixes this issue that on my machine (Windows 10 on all browsers) every newline was replaced by two newlines. So `\r\n` was replaced by `\r\r\n` which is interpreted as two newlines.