### PR TITLE
#268 Fix HTML validation by specifying multipart/form-data enctype.

### DIFF
--- a/code/dabblet.js
+++ b/code/dabblet.js
@@ -51,6 +51,7 @@ window.Dabblet = $u.attach({
 			var form = $u.element.create('form', {
 				properties: {
 					action: 'http://validator.w3.org/check',
+					enctype: 'multipart/form-data',
 					method: 'POST',
 					target: '_blank'
 				},


### PR DESCRIPTION
I added the `enctype` to `Dabblet.validate.HTML()` to fix the error shown by validator.w3.org.